### PR TITLE
legg til endret_av felt paa Cv og CvDVH schema

### DIFF
--- a/src/main/avro/Cv.avdl
+++ b/src/main/avro/Cv.avdl
@@ -240,6 +240,12 @@ protocol CvProtocol {
     SLETT
   }
 
+  enum EndretAv {
+    VEILEDER,
+    SYSTEMBRUKER,
+    PERSONBRUKER
+  }
+
   // TODO Samtykke/Hjemmel?
   // Inntill videre er samtykke/hjemmel innbakt i cv.synlig_for_arbeidsgiver og cv.synlig_for_veileder.
 
@@ -251,6 +257,9 @@ protocol CvProtocol {
    */
   record Melding {
     Meldingstype meldingstype;
+
+    union {null, EndretAv} endret_av = null;
+
     union {null, OpprettCv} opprett_cv = null;
     union {null, EndreCv} endre_cv = null;
     union {null, SlettCv} slett_cv = null;

--- a/src/main/avro/CvDVH.avdl
+++ b/src/main/avro/CvDVH.avdl
@@ -185,6 +185,12 @@ protocol CvDVHProtocol {
     SLETT
   }
 
+  enum EndretAv {
+    VEILEDER,
+    SYSTEMBRUKER,
+    PERSONBRUKER
+  }
+
   /** Kun ett av feltene endre eller slett vil ha verdi.
       Dette er basert på meldingstype.
       Hvis meldingstype f.eks er ENDRE vil både endre_jobbprofil og endre_cv kunne ha verdi
@@ -193,6 +199,9 @@ protocol CvDVHProtocol {
    */
   record MeldingDVH {
     MeldingstypeDVH meldingstype;
+
+    union {null, EndretAv} endret_av = null;
+
     union {null, EndreCvDVH} endre_cv = null;
     union {null, SlettCvDVH} slett_cv = null;
 


### PR DESCRIPTION
Dette er for aa kunne forstaa hvem som endret CV-en. Feltet er et
enum som inneholder en av tre verdier:
- PERSONBRUKER
- VEILEDER
- SYSTEMBRUKER